### PR TITLE
chore: update deps.

### DIFF
--- a/.github/workflows/check-code.yaml
+++ b/.github/workflows/check-code.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
 
       - uses: "golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9" # v8.0.0
         with:
@@ -28,7 +28,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
 
       - uses: "actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5" # v5.5.0
         with:
@@ -44,7 +44,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
 
       - name: "Run spell check"
         run: "make spell-check"
@@ -59,7 +59,7 @@ jobs:
           - "1.23"
           - "1.24"
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
 
       - uses: "actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5" # v5.5.0
         with:

--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
 
       - uses: "actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5" # v5.5.0
         with:

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/mythrnr/paypayopa-sdk-go
 go 1.23
 
 require (
-	github.com/golang-jwt/jwt/v5 v5.2.3
-	github.com/stretchr/testify v1.10.0
+	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,13 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang-jwt/jwt/v5 v5.2.3 h1:kkGXqQOBSDDWRhWNXTFpqGSCMyh/PLnqUvMGJPDJDs0=
-github.com/golang-jwt/jwt/v5 v5.2.3/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
This pull request updates dependencies to improve security and maintainability. The main changes include upgrading the `actions/checkout` GitHub Action to version 5.0.0 across all workflow files and bumping key Go module dependencies to their latest versions.

Dependency and workflow updates:

**GitHub Actions:**
* Upgraded `actions/checkout` from version 4.2.2 to 5.0.0 in `.github/workflows/check-code.yaml` and `.github/workflows/scan-vulnerabilities.yaml` to ensure compatibility with the latest GitHub Actions features and security patches. [[1]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L20-R20) [[2]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L31-R31) [[3]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L47-R47) [[4]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L62-R62) [[5]](diffhunk://#diff-cc9d9d3c0c78f6b5ef4c43e5c23501e6420a0e25eff660af96e7fdaee9e519ddL17-R17)

**Go module dependencies:**
* Updated `github.com/golang-jwt/jwt/v5` from v5.2.3 to v5.3.0 and `github.com/stretchr/testify` from v1.10.0 to v1.11.1 in `go.mod` to pull in bug fixes and improvements.