### PR TITLE
chore: update deps, use any instead interface{}.

### DIFF
--- a/.github/workflows/check-code.yaml
+++ b/.github/workflows/check-code.yaml
@@ -17,9 +17,9 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
-      - uses: "golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9" # v8.0.0
+      - uses: "golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601" # v9.1.0
         with:
           version: "latest"
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
       - name: "Run spell check"
         run: "make spell-check"
@@ -46,9 +46,9 @@ jobs:
           - "1.24"
           - "1.25"
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
-      - uses: "actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00" # v6.0.0
+      - uses: "actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c" # v6.1.0
         with:
           go-version: "${{ matrix.go }}"
 

--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -15,9 +15,9 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
-      - uses: "actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00" # v6.0.0
+      - uses: "actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c" # v6.1.0
         with:
           go-version: "1.25"
 

--- a/api_qrcode.go
+++ b/api_qrcode.go
@@ -11,7 +11,7 @@ type CreateQRCodePayload struct {
 	Amount              *MoneyAmount         `json:"amount"`
 	OrderDescription    string               `json:"orderDescription"`
 	OrderItems          []*MerchantOrderItem `json:"orderItems"`
-	Metadata            interface{}          `json:"metadata"`
+	Metadata            any                  `json:"metadata"`
 	CodeType            CodeType             `json:"codeType"`
 	StoreInfo           string               `json:"storeInfo"`
 	StoreID             string               `json:"storeId"`

--- a/client.go
+++ b/client.go
@@ -51,7 +51,7 @@ func newClientWithHTTPClient(creds *Credentials, hc *http.Client) *opaClient {
 func (c *opaClient) GET(
 	ctx context.Context,
 	path string,
-	res interface{},
+	res any,
 ) (*ResultInfo, error) {
 	req, err := c.Request(ctx, http.MethodGet, path, nil)
 	if err != nil {
@@ -86,8 +86,8 @@ func (c *opaClient) DELETE(
 func (c *opaClient) POST(
 	ctx context.Context,
 	path string,
-	res interface{},
-	req interface{},
+	res any,
+	req any,
 ) (*ResultInfo, error) {
 	rq, err := c.Request(ctx, http.MethodPost, path, req)
 	if err != nil {
@@ -109,7 +109,7 @@ func (c *opaClient) POST(
 func (c *opaClient) Request(
 	ctx context.Context,
 	method, path string,
-	req interface{},
+	req any,
 ) (*http.Request, error) {
 	var reader io.Reader
 
@@ -136,7 +136,7 @@ func (c *opaClient) Request(
 //
 // Do はリクエストを送信する.
 // res にレスポンスを格納し, 処理結果とエラーオブジェクトを返す.
-func (c *opaClient) Do(req *http.Request, res interface{}) (*ResultInfo, error) {
+func (c *opaClient) Do(req *http.Request, res any) (*ResultInfo, error) {
 	ctx, cancel := context.WithTimeout(
 		req.Context(),
 		getTimeout(req.Context()),

--- a/client_inner_test.go
+++ b/client_inner_test.go
@@ -120,7 +120,7 @@ func Test_opaClient_Request(t *testing.T) {
 			context.Background(),
 			http.MethodPost,
 			"%%%%-invalid-url-%%%%",
-			map[string]interface{}{},
+			map[string]any{},
 		)
 
 		actual := &url.Error{}
@@ -146,7 +146,7 @@ func Test_opaClient_Request(t *testing.T) {
 			context.Background(),
 			http.MethodPost,
 			"/test",
-			map[string]interface{}{},
+			map[string]any{},
 		)
 
 		require.NoError(t, err)
@@ -181,7 +181,7 @@ func Test_opaClient_Do(t *testing.T) {
 			nil,
 		)
 
-		res := map[string]interface{}{}
+		res := map[string]any{}
 		info, err := client.Do(req, res)
 
 		assert.Nil(t, info)
@@ -213,7 +213,7 @@ func Test_opaClient_Do(t *testing.T) {
 			nil,
 		)
 
-		res := map[string]interface{}{}
+		res := map[string]any{}
 		info, err := client.Do(req, res)
 
 		assert.Nil(t, info)
@@ -256,7 +256,7 @@ func Test_opaClient_Do(t *testing.T) {
 			nil,
 		)
 
-		res := map[string]interface{}{}
+		res := map[string]any{}
 		info, err := client.Do(req, res)
 
 		assert.Nil(t, info)
@@ -291,7 +291,7 @@ func Test_opaClient_Do(t *testing.T) {
 			nil,
 		)
 
-		res := map[string]interface{}{}
+		res := map[string]any{}
 		info, err := client.Do(req, res)
 		actual := &json.SyntaxError{}
 
@@ -333,7 +333,7 @@ func Test_opaClient_Do(t *testing.T) {
 			nil,
 		)
 
-		res := map[string]interface{}{}
+		res := map[string]any{}
 		info, err := client.Do(req, res)
 
 		require.NoError(t, err)

--- a/jwt.go
+++ b/jwt.go
@@ -39,7 +39,7 @@ func decodeAuthorizationResponseToken(
 
 	if _, err := jwt.ParseWithClaims(
 		token, &claims,
-		func(_ *jwt.Token) (interface{}, error) {
+		func(_ *jwt.Token) (any, error) {
 			return []byte(creds.apiKeySecret), nil
 		},
 	); err != nil {


### PR DESCRIPTION
This pull request updates the codebase to use the new Go 1.18+ `any` type instead of the older `interface{}` type, improving clarity and consistency. It also upgrades several GitHub Actions to their latest major versions for better reliability and security.

**Type migration to `any`:**

* Updated all function signatures, struct fields, and test cases in `client.go`, `api_qrcode.go`, `client_inner_test.go`, and `jwt.go` to use the `any` type instead of `interface{}`. This modernizes the code and aligns with Go best practices. [[1]](diffhunk://#diff-9ae5adab44d24632d7279a8edb9ede73093ce72d6ac16214560b14af40805fc5L14-R14) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL54-R54) [[3]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL89-R90) [[4]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL112-R112) [[5]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL139-R139) [[6]](diffhunk://#diff-bddb063785a08fef96a4a4be29592d858e0ce0a2fcfd15e3a110e32523466156L123-R123) [[7]](diffhunk://#diff-bddb063785a08fef96a4a4be29592d858e0ce0a2fcfd15e3a110e32523466156L149-R149) [[8]](diffhunk://#diff-bddb063785a08fef96a4a4be29592d858e0ce0a2fcfd15e3a110e32523466156L184-R184) [[9]](diffhunk://#diff-bddb063785a08fef96a4a4be29592d858e0ce0a2fcfd15e3a110e32523466156L216-R216) [[10]](diffhunk://#diff-bddb063785a08fef96a4a4be29592d858e0ce0a2fcfd15e3a110e32523466156L259-R259) [[11]](diffhunk://#diff-bddb063785a08fef96a4a4be29592d858e0ce0a2fcfd15e3a110e32523466156L294-R294) [[12]](diffhunk://#diff-bddb063785a08fef96a4a4be29592d858e0ce0a2fcfd15e3a110e32523466156L336-R336) [[13]](diffhunk://#diff-5e3b638232aa08473d7ebbb49c995075a7e7200d9589b1ca7f5b67eb98d38fbeL42-R42)

**CI/CD workflow upgrades:**

* Upgraded `actions/checkout` from v5.0.0 to v6.0.0 in `.github/workflows/check-code.yaml` and `.github/workflows/scan-vulnerabilities.yaml` for improved performance and security. [[1]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L20-R22) [[2]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L34-R34) [[3]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L49-R51) [[4]](diffhunk://#diff-cc9d9d3c0c78f6b5ef4c43e5c23501e6420a0e25eff660af96e7fdaee9e519ddL18-R20)
* Upgraded `golangci/golangci-lint-action` from v8.0.0 to v9.1.0 in `.github/workflows/check-code.yaml` for better linting support.
* Upgraded `actions/setup-go` from v6.0.0 to v6.1.0 in `.github/workflows/check-code.yaml` and `.github/workflows/scan-vulnerabilities.yaml` for improved Go environment setup. [[1]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L49-R51) [[2]](diffhunk://#diff-cc9d9d3c0c78f6b5ef4c43e5c23501e6420a0e25eff660af96e7fdaee9e519ddL18-R20)